### PR TITLE
Fix subdir logic and an edge case the path #[path = "..."] attribute

### DIFF
--- a/cargo-files-core/src/lib.rs
+++ b/cargo-files-core/src/lib.rs
@@ -20,8 +20,8 @@ pub enum Error {
     ManifestError(#[from] io::Error),
     #[error("there was an error parsing a source file: {0}")]
     ParseError(#[from] syn::Error),
-    #[error("could not find module")]
-    ModuleNotFound,
+    #[error("could not find module: {0:?}")]
+    ModuleNotFound((parser::Module, std::path::PathBuf)),
     #[error("source file must have parent")]
     NoParent,
     #[error("source file must have a stem")]

--- a/cargo-files-core/src/parser.rs
+++ b/cargo-files-core/src/parser.rs
@@ -21,6 +21,16 @@ impl<'ast> Visit<'ast> for ModVisitor {
             let Meta::NameValue(meta) = &attr.meta else {
                 continue;
             };
+            if !meta
+                .path
+                .get_ident()
+                .map(|i| i.to_string())
+                .as_ref()
+                .map_or(false, |i| i == "path")
+            {
+                continue;
+            };
+
             let Expr::Lit(ExprLit {
                 lit: Lit::Str(lit), ..
             }) = &meta.value

--- a/cargo-files-core/src/parser.rs
+++ b/cargo-files-core/src/parser.rs
@@ -45,7 +45,7 @@ impl<'ast> Visit<'ast> for ModVisitor {
 }
 
 #[derive(Debug)]
-struct Module {
+pub struct Module {
     parts: Vec<String>,
 
     /// An optional path override, set using the #[path = "..."] attribute.
@@ -83,7 +83,7 @@ impl Module {
             return if base_path.exists() {
                 Ok(base_path)
             } else {
-                Err(Error::ModuleNotFound)
+                Err(Error::ModuleNotFound((self, relative_to.to_path_buf())))
             };
         }
 
@@ -97,7 +97,7 @@ impl Module {
         if base_path.exists() {
             Ok(base_path)
         } else {
-            Err(Error::ModuleNotFound)
+            Err(Error::ModuleNotFound((self, relative_to.to_path_buf())))
         }
     }
 }

--- a/cargo-files-core/src/parser.rs
+++ b/cargo-files-core/src/parser.rs
@@ -70,6 +70,12 @@ impl Module {
         if let Some(path) = self.path.as_ref() {
             let source_path = relative_to
                 .parent()
+                .map(|p| p.to_path_buf())
+                .map(|p| {
+                    let mut parts = self.parts.clone();
+                    parts.pop();
+                    parts.iter().fold(p, |acc, part| acc.join(part))
+                })
                 .map(|p| p.join(path))
                 .and_then(|p| p.as_path().canonicalize().ok());
             return match source_path {

--- a/cargo-files-core/src/parser.rs
+++ b/cargo-files-core/src/parser.rs
@@ -68,7 +68,10 @@ impl Module {
         // Handling for #[path = "..."] attribute.
         // https://doc.rust-lang.org/reference/items/modules.html#the-path-attribute
         if let Some(path) = self.path.as_ref() {
-            let source_path = relative_to.parent().map(|p| p.join(path));
+            let source_path = relative_to
+                .parent()
+                .map(|p| p.join(path))
+                .and_then(|p| p.as_path().canonicalize().ok());
             return match source_path {
                 Some(p) if p.exists() => Ok(p),
                 _ => Err(Error::ModuleNotFound((self, relative_to.to_path_buf()))),


### PR DESCRIPTION
cargo-files in master real world test failed in two cases as far as I can tell:
* module defined like below:

```
mod subdir {
    mod subdir_module;
}
```

* module defination with empty comments like below
```
///
mod intern;
```
Here is an [cargo project](https://github.com/declantsien/cargo-files-test-cases) for test them 